### PR TITLE
Fix condition for checking day of week

### DIFF
--- a/semantic/dates.py
+++ b/semantic/dates.py
@@ -227,7 +227,7 @@ class DateService(object):
                 d = self.now
             elif tomorrow:
                 d = self.now + datetime.timedelta(days=1)
-            elif day_of_week is not None:
+            elif type(day_of_week) == int:
                 current_day_of_week = self.now.weekday()
                 num_days_away = (day_of_week - current_day_of_week) % 7
 

--- a/semantic/dates.py
+++ b/semantic/dates.py
@@ -227,7 +227,7 @@ class DateService(object):
                 d = self.now
             elif tomorrow:
                 d = self.now + datetime.timedelta(days=1)
-            elif day_of_week:
+            elif day_of_week is not None:
                 current_day_of_week = self.now.weekday()
                 num_days_away = (day_of_week - current_day_of_week) % 7
 


### PR DESCRIPTION
This issue occurs while testing with phrases containing "Monday".
DateService().extractDate("monday") gave me an "UnboundLocalError: local variable 'd' referenced before assignment" 
On inspection, I found that "monday" being the first element in the **daysOfWeek** list, extractDayOfWeek() returns 0, and the condition "elif day_of_week" fails because obviously bool(0) is False.
This commit changes the condition to a more explicit one.
